### PR TITLE
Click anywhere to toggle switch

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -76,50 +76,46 @@ class _CrazySwitchState extends
     return AnimatedBuilder(
       animation: _animationController,
       builder: (context, child){
-        return Container(
-          width: 110,
-          height: 50,
-          padding: EdgeInsets.fromLTRB(0, 6, 0, 6),
-          decoration: BoxDecoration(
-            color: isChecked ? Colors.green : Colors.red,
-            borderRadius: BorderRadius.all(
-              Radius.circular(40),
-            ),
-            boxShadow: [
-              BoxShadow(
-                color: isChecked ? Colors.green : Colors.red,
-                blurRadius: 12,
-                offset: Offset(0, 8)
-              )
-            ]
-          ),
-          child: Stack(
-            children: <Widget>[
-              Align(
-                alignment: _animation.value,
-                child: GestureDetector(
-                  onTap: (){
-                    setState(() {
-                      if(_animationController.isCompleted){
-                        _animationController.reverse();
-                      }else{
-                        _animationController.forward();
-                      }
+        return GestureDetector(
+          onTap: (){
+            setState(() {
+              if(_animationController.isCompleted){
+                _animationController.reverse();
+              }else{
+                _animationController.forward();
+              }
 
-                      isChecked = !isChecked;
-                    });
-                  },
-                  child: Container(
-                    width: 50,
-                    height: 50,
-                    decoration: BoxDecoration(
-                      shape: BoxShape.circle,
-                      color: Colors.white,
-                    ),
-                  ),
+              isChecked = !isChecked;
+            });
+          },
+          child: Container(
+            width: 110,
+            height: 50,
+            padding: EdgeInsets.fromLTRB(0, 6, 0, 6),
+            decoration: BoxDecoration(
+                color: isChecked ? Colors.green : Colors.red,
+                borderRadius: BorderRadius.all(
+                  Radius.circular(40),
                 ),
-              )
-            ],
+                boxShadow: [
+                  BoxShadow(
+                      color: isChecked ? Colors.green : Colors.red,
+                      blurRadius: 12,
+                      offset: Offset(0, 8)
+                  )
+                ]
+            ),
+            child: Align(
+              alignment: _animation.value,
+              child: Container(
+                width: 50,
+                height: 50,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: Colors.white,
+                ),
+              ),
+            ),
           ),
         );
       },


### PR DESCRIPTION
Fixed the issue which caused the toggle button only switch when the circle is pressed. 🥳🥳 Now, press anywhere on the button and the state will be toggled.